### PR TITLE
Accept package-db paths with spaces

### DIFF
--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -218,7 +218,7 @@ getSandboxPackageDB sandboxPath = do
   where
     pkgDbKey = "package-db:"
     parse = head . filter (pkgDbKey `isPrefixOf`) . lines
-    extractValue = fst . break isSpace . dropWhile isSpace . drop (length pkgDbKey)
+    extractValue = fst . break (`elem` "\n\r") . dropWhile isSpace . drop (length pkgDbKey)
 
 
 findCabalFile :: FilePath -> IO (Maybe FilePath)


### PR DESCRIPTION
As titled. I know paths with spaces are terrible things, but it's really hard for me to get rid of the space in my case because it breaks other things and GHC manages to deal with them, so yeah.