### PR TITLE
cache Config after the first command

### DIFF
--- a/hdevtools.cabal
+++ b/hdevtools.cabal
@@ -1,5 +1,5 @@
 name:                hdevtools
-version:             0.1.2.2
+version:             0.1.3.0
 synopsis:            Persistent GHC powered background server for FAST haskell development tools
 description:
     'hdevtools' is a backend for text editor plugins, to allow for things such as


### PR DESCRIPTION
Running newConfig for every command is too expensive with stack projects - see #9. This change will cache the Config with the first command execution and re-use it after that.