### PR TITLE
Cache stack config as long stack.yaml path is unchanged

### DIFF
--- a/hdevtools.cabal
+++ b/hdevtools.cabal
@@ -1,5 +1,5 @@
 name:                hdevtools
-version:             0.1.2.2
+version:             0.1.3.0
 synopsis:            Persistent GHC powered background server for FAST haskell development tools
 description:
     'hdevtools' is a backend for text editor plugins, to allow for things such as

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -17,6 +17,7 @@ import Client (getServerStatus, serverCommand, stopServer)
 import CommandArgs
 import Daemonize (daemonize)
 import Server (startServer, createListenSocket)
+import Stack (findStackYaml)
 import Types (Command(..), CommandExtra(..), emptyCommandExtra)
 
 absoluteFilePath :: FilePath -> IO FilePath
@@ -56,11 +57,13 @@ main = do
     let argPath = pathArg args
     dir  <- maybe getCurrentDirectory (return . takeDirectory) argPath
     mCabalFile <- findCabalFile dir >>= traverse absoluteFilePath
+    mStackYaml <- findStackYaml dir
     let extra = emptyCommandExtra
-                    { ceGhcOptions  = ghcOpts args
-                    , ceCabalConfig = mCabalFile
-                    , cePath        = argPath
+                    { cePath = argPath
+                    , ceGhcOptions  = ghcOpts args
+                    , ceCabalFilePath = mCabalFile
                     , ceCabalOptions = cabalOpts args
+                    , ceStackYamlPath = mStackYaml
                     }
     let defaultSocketPath = maybe "" takeDirectory mCabalFile </> defaultSocketFile
     let sock = fromMaybe defaultSocketPath $ socket args

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -9,17 +9,19 @@ module Types
 import System.Exit (ExitCode)
 
 data CommandExtra = CommandExtra
-  { ceGhcOptions  :: [String]
-  , ceCabalConfig :: Maybe FilePath
-  , cePath        :: Maybe FilePath
+  { cePath :: Maybe FilePath
+  , ceGhcOptions :: [String]
+  , ceCabalFilePath :: Maybe FilePath
   , ceCabalOptions :: [String]
+  , ceStackYamlPath :: Maybe FilePath
   } deriving (Read, Show)
 
 emptyCommandExtra :: CommandExtra
-emptyCommandExtra = CommandExtra { ceGhcOptions  = []
-                                 , ceCabalConfig = Nothing
-                                 , cePath        = Nothing
+emptyCommandExtra = CommandExtra { cePath = Nothing
+                                 , ceGhcOptions  = []
+                                 , ceCabalFilePath = Nothing
                                  , ceCabalOptions = []
+                                 , ceStackYamlPath = Nothing
                                  }
 
 data ServerDirective


### PR DESCRIPTION
@jeremyjh I extended your PR #10. What do you think about this?

Related to #9 

Runtimes on my machine:
```
[ch1bo][~/code/hdevtools][⌥ cache-stack-config] ➜ time hdevtools check src/Main.hs
stack exec --no-ghc-package-path hdevtools -- check src/Main.hs  0.33s user 0.08s system 12% cpu 3.327 total
[ch1bo][~/code/hdevtools][⌥ cache-stack-config] ➜ time hdevtools check src/Main.hs
stack exec --no-ghc-package-path hdevtools -- check src/Main.hs  0.33s user 0.06s system 95% cpu 0.414 total
[ch1bo][~/code/hdevtools][⌥ cache-stack-config] ➜ time hdevtools check src/Main.hs
stack exec --no-ghc-package-path hdevtools -- check src/Main.hs  0.31s user 0.08s system 95% cpu 0.413 total
```
