### PR TITLE
Cope with Cabal API Changes

### DIFF
--- a/hdevtools.cabal
+++ b/hdevtools.cabal
@@ -78,7 +78,7 @@ executable hdevtools
                        unix
 
   if impl(ghc == 7.6.*)
-    build-depends:     Cabal == 1.16.*
+    build-depends:     Cabal >= 1.16
 
   if impl(ghc >= 7.7)
     build-depends:     Cabal >= 1.18

--- a/hdevtools.cabal
+++ b/hdevtools.cabal
@@ -4,7 +4,7 @@ synopsis:            Persistent GHC powered background server for FAST haskell d
 license:             MIT
 license-file:        LICENSE
 author:              Bit Connor
-maintainer:          Sebastian Nagel <sebastian.nagel@ncoding.at>, 
+maintainer:          Sebastian Nagel <sebastian.nagel@ncoding.at>,
                      Ranjit Jhala <jhala@cs.ucsd.edu>
 copyright:           See AUTHORS file
 category:            Development
@@ -49,7 +49,6 @@ source-repository head
 executable hdevtools
   hs-source-dirs:      src
   ghc-options:         -Wall
-  cpp-options:         -DCABAL
   main-is:             Main.hs
   other-modules:       Cabal,
                        Client,
@@ -80,14 +79,10 @@ executable hdevtools
 
   if impl(ghc == 7.6.*)
     build-depends:     Cabal == 1.16.*
-    cpp-options:       -DENABLE_CABAL
 
   if impl(ghc >= 7.7)
     build-depends:     Cabal >= 1.18
-    cpp-options:       -DENABLE_CABAL
 
   if impl(ghc >= 7.9)
     build-depends:     Cabal >= 1.22,
                        bin-package-db
-
-    cpp-options:       -DENABLE_CABAL

--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -21,7 +21,7 @@ import Distribution.PackageDescription.Parse (readPackageDescription)
 import Distribution.Simple.Configure (configure)
 import Distribution.Simple.LocalBuildInfo (LocalBuildInfo(..), ComponentLocalBuildInfo(..),
     Component(..), ComponentName(..),
-#if __GLASGOW_HASKELL__ < 707
+#if !MIN_VERSION_Cabal(1,18,0)
     allComponentsBy,
 #endif
     componentBuildInfo, foldComponent)
@@ -53,7 +53,7 @@ componentName =
                   (CBenchName . benchmarkName)
 
 getComponentLocalBuildInfo :: LocalBuildInfo -> ComponentName -> ComponentLocalBuildInfo
-#if __GLASGOW_HASKELL__ >= 707
+#if MIN_VERSION_Cabal(1,18,0)
 getComponentLocalBuildInfo lbi cname = getLocalBuildInfo cname $ componentsConfigs lbi
     where getLocalBuildInfo cname' ((cname'', clbi, _):cfgs) =
             if cname' == cname'' then clbi else getLocalBuildInfo cname' cfgs
@@ -77,7 +77,7 @@ getComponentLocalBuildInfo lbi (CBenchName name) =
         Just clbi -> clbi
 #endif
 
-#if __GLASGOW_HASKELL__ >= 707
+#if MIN_VERSION_Cabal(1,18,0)
 -- TODO: Fix callsites so we don't need `allComponentsBy`. It was taken from
 -- http://hackage.haskell.org/package/Cabal-1.16.0.3/docs/src/Distribution-Simple-LocalBuildInfo.html#allComponentsBy
 -- since it doesn't exist in Cabal 1.18.*

--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -172,7 +172,7 @@ getPackageGhcOpts path mbStack opts = do
                                        }
                 (ghcInfo,mbPlatform,_) <- GHC.configure silent Nothing Nothing defaultProgramConfiguration
 
-#if MIN_VERSION_Cabal(1,25,0)
+#if MIN_VERSION_Cabal(1,23,2)
 -- API Change:
 -- Distribution.Simple.Program.GHC.renderGhcOptions now takes Platform argument
 -- renderGhcOptions :: Compiler -> Platform -> GhcOptions -> [String]
@@ -203,7 +203,7 @@ getPackageGhcOpts path mbStack opts = do
                                        , ghcOptSourcePath = map (baseDir </>) (ghcOptSourcePath ghcOpts')
                                        }
 #endif
-#if MIN_VERSION_Cabal(1,25,0)
+#if MIN_VERSION_Cabal(1,23,2)
 -- API Change:
 -- Distribution.Simple.Program.GHC.renderGhcOptions now takes Platform argument
 -- renderGhcOptions :: Compiler -> Platform -> GhcOptions -> [String]

--- a/src/CommandArgs.hs
+++ b/src/CommandArgs.hs
@@ -6,31 +6,20 @@ module CommandArgs
     )
 where
 
+import Data.Version (showVersion)
+import Paths_hdevtools (version)
 import System.Console.CmdArgs.Implicit
 import System.Environment (getProgName)
 import System.Info (arch, os)
 import qualified Config
 
-#ifdef CABAL
-import Data.Version (showVersion)
-import Paths_hdevtools (version)
-#endif
-
 programVersion :: String
 programVersion =
-#ifdef CABAL
     "version " ++ showVersion version
-#else
-    "unknown-version (not built with cabal)"
-#endif
 
 cabalVersion :: String
 cabalVersion =
-#ifdef ENABLE_CABAL
     "cabal-" ++ VERSION_Cabal
-#else
-    "no cabal support"
-#endif
 
 fullVersion :: String
 fullVersion =
@@ -160,11 +149,7 @@ check :: Annotate Ann
 check = record dummyCheck
     [ socket   := def += typFile      += help "socket file to use"
     , ghcOpts  := def += typ "OPTION" += help "ghc options"
-#ifdef ENABLE_CABAL
     , cabalOpts := def += typ "OPTION"  += help "cabal options"
-#else
-    , cabalOpts := def += ignore
-#endif
     , path     := def += typFile      += help "path to target file"
     , file     := def += typFile      += argPos 0 += opt ""
     , json     := def                 += help "render output as JSON"
@@ -174,11 +159,7 @@ moduleFile :: Annotate Ann
 moduleFile = record dummyModuleFile
     [ socket   := def += typFile += help "socket file to use"
     , ghcOpts  := def += typ "OPTION" += help "ghc options"
-#ifdef ENABLE_CABAL
     , cabalOpts := def += typ "OPTION"  += help "cabal options"
-#else
-    , cabalOpts := def += ignore
-#endif
     , module_  := def += typ "MODULE" += argPos 0
     ] += help "Get the haskell source file corresponding to a module name"
 
@@ -186,11 +167,7 @@ info :: Annotate Ann
 info = record dummyInfo
     [ socket     := def += typFile      += help "socket file to use"
     , ghcOpts    := def += typ "OPTION" += help "ghc options"
-#ifdef ENABLE_CABAL
     , cabalOpts := def += typ "OPTION"  += help "cabal options"
-#else
-    , cabalOpts := def += ignore
-#endif
     , path       := def += typFile      += help "path to target file"
     , file       := def += typFile      += argPos 0 += opt ""
     , identifier := def += typ "IDENTIFIER" += argPos 1
@@ -200,11 +177,7 @@ type_ :: Annotate Ann
 type_ = record dummyType
     [ socket   := def += typFile += help "socket file to use"
     , ghcOpts  := def += typ "OPTION" += help "ghc options"
-#ifdef ENABLE_CABAL
     , cabalOpts := def += typ "OPTION"  += help "cabal options"
-#else
-    , cabalOpts := def += ignore
-#endif
     , path     := def += typFile      += help "path to target file"
     , file     := def += typFile      += argPos 0 += opt ""
     , line     := def += typ "LINE"   += argPos 1
@@ -215,11 +188,7 @@ findSymbol :: Annotate Ann
 findSymbol = record dummyFindSymbol
     [ socket   := def += typFile += help "socket file to use"
     , ghcOpts  := def += typ "OPTION" += help "ghc options"
-#ifdef ENABLE_CABAL
     , cabalOpts := def += typ "OPTION"  += help "cabal options"
-#else
-    , cabalOpts := def += ignore
-#endif
     , symbol   := def += typ "SYMBOL" += argPos 0
     , files    := def += typFile += args
     ] += help "List the modules where the given symbol could be found"

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,9 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps: []
-
-# for GHC 7.8
-# resolver: lts-2.15
-
-# for GHC 7.10
-resolver: lts-5.5
+resolver: lts-5.8


### PR DESCRIPTION
I couldn't compile against the latest Cabal library without these changes.
I tested with the master branch of Cabal (1.25.0) but it should fix compiling against earlier versions too.