### PR TITLE
Fix compilation with GHC-8.0.1

### DIFF
--- a/hdevtools.cabal
+++ b/hdevtools.cabal
@@ -83,6 +83,10 @@ executable hdevtools
   if impl(ghc >= 7.7)
     build-depends:     Cabal >= 1.18
 
-  if impl(ghc >= 7.9)
+  if impl(ghc >= 7.9 && < 8.0)
     build-depends:     Cabal >= 1.22,
                        bin-package-db
+
+  if impl(ghc >= 8.0)
+    build-depends:     Cabal >= 1.24,
+                       ghc-boot >= 8.0

--- a/src/Info.hs
+++ b/src/Info.hs
@@ -176,7 +176,10 @@ pretty dflags =
 pretty :: GHC.Type -> String
 pretty =
 #endif
-#if __GLASGOW_HASKELL__ >= 708
+#if __GLASGOW_HASKELL__ >= 800
+    Pretty.renderStyle
+      Pretty.style{ Pretty.lineLength = 0, Pretty.mode = Pretty.OneLineMode }
+#elif __GLASGOW_HASKELL__ >= 708
     Pretty.showDoc Pretty.OneLineMode 0
 #else
     Pretty.showDocWith Pretty.OneLineMode


### PR DESCRIPTION
Fixes #20 

Since there is no test suite, I'm not 100% sure the behavior is as expected. I only did rudimentary runtime tests and used it with hspec.

One thing in particular is unclear to me whether the newly introduced argument `DynFlags.WarnReason` in `logAction` shall be ignored (as is done in the patch) or whether it should be utilized somehow.