### PR TITLE
Add explicit resolver to stack install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ editor plugins that supply this integration is below.
 But before you do anything, you must first install `hdevtools` itself. The
 easiest way is from [Stackage][14] using [stack][15]:
 ```
-$ stack install hdevtools
+$ stack --resolver lts-7.0 install hdevtools
 ```
 
 **Note:** `hdevtools` automatically discovers compiler and libraries installed


### PR DESCRIPTION
`stack install` defaults to the latest resolver available, which fails to compile in 7.1.