### PR TITLE
handle source error

### DIFF
--- a/src/CommandLoop.hs
+++ b/src/CommandLoop.hs
@@ -217,8 +217,7 @@ loadTarget files conf = do
             when (GHC.needsTemplateHaskell graph) $ do
                 flags <- GHC.getSessionDynFlags
                 void . GHC.setSessionDynFlags $ flags { GHC.hscTarget = GHC.HscInterpreted, GHC.ghcLink = GHC.LinkInMemory }
-            let handler err = GHC.printException err >> return GHC.Failed
-            fmap Just $ GHC.handleSourceError handler (GHC.load GHC.LoadAllTargets)
+            Just <$> GHC.load GHC.LoadAllTargets
         else return Nothing
 
 withTargets :: ClientSend -> [FilePath] -> Config -> GHC.Ghc () -> GHC.Ghc ()

--- a/src/CommandLoop.hs
+++ b/src/CommandLoop.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP, ViewPatterns #-}
+
 module CommandLoop
     ( newCommandLoopState
     , Config(..)
@@ -7,6 +8,7 @@ module CommandLoop
     , startCommandLoop
     ) where
 
+import Control.Exception
 import Control.Applicative ((<|>))
 import Control.Monad (when, void)
 import Data.IORef
@@ -25,6 +27,8 @@ import qualified Exception (ExceptionMonad)
 import qualified DynFlags
 #endif
 import qualified GHC
+import qualified GhcPlugins as GHC
+import qualified ErrUtils as GHC
 import qualified GHC.Paths
 import qualified Outputable
 import System.Posix.Types (EpochTime)
@@ -136,15 +140,37 @@ startCommandLoop state clientSend getNextCommand initialConfig mbInitialCommand 
             Just (cmd, config) ->
                 if forceReconfig || (config /= initialConfig)
                     then return (Just (cmd, config))
-                    else sendErrors (runCommand state clientSend initialConfig cmd) >> processNextCommand False
+                    else do
+                        sendErrors (runCommand state clientSend initialConfig cmd)
+                        processNextCommand False
 
     sendErrors :: GHC.Ghc () -> GHC.Ghc ()
-    sendErrors action = GHC.gcatch action $ \e -> do
-        liftIO $ mapM_ clientSend
-            [ ClientStderr $ GHC.showGhcException e ""
-            , ClientExit (ExitFailure 1)
-            ]
-        return ()
+    sendErrors action = do
+            action `GHC.gcatch` ghcError
+                   `GHC.gcatch` sourceError
+                   `GHC.gcatch` unknownError
+        where
+            ghcError :: GHC.GhcException -> GHC.Ghc ()
+            ghcError = die . flip GHC.showGhcException ""
+
+            unknownError :: SomeException -> GHC.Ghc ()
+            unknownError = die . show
+
+            sourceError :: GHC.SourceError -> GHC.Ghc ()
+            sourceError = report
+
+            die msg = liftIO $ mapM_ clientSend
+                [ ClientStderr msg
+                , ClientExit (ExitFailure 1)
+                ]
+
+            report (GHC.srcErrorMessages -> bag) = do
+                flags <- GHC.getSessionDynFlags
+                let msgs = map (Outputable.showSDoc flags) $ GHC.pprErrMsgBagWithLoc bag
+                liftIO $ do
+                    mapM_ (logActionSend state clientSend GHC.SevError) msgs
+                    clientSend $ ClientExit ExitSuccess
+
 
 doMaybe :: Monad m => Maybe a -> (a -> m ()) -> m ()
 doMaybe Nothing _ = return ()


### PR DESCRIPTION
Problem being solved:
type  error:
```
% cat Foo.hs
main = return ()
% hdevtools check Foo.hs
/home/pacak/hdevtools/Foo.hs:1:1: Warning:
    Top-level binding with no type signature: main :: IO ()
% hdevtools admin --status
Server is running.
```

source error:
```
% cat Bar.hs
import Perlude
main = return ()
% hdevtools check Bar.hs
hdevtools: <socket: 3>: hGetLine: end of file
% hdevtools admin --status
hdevtools: connect: does not exist (No such file or directory)
```

new version:
```
% hdevtools check Bar.hs
/home/pacak/hdevtools/Bar.hs:1:8:
    Could not find module ‘Perlude’
    Perhaps you meant Prelude (from base-4.8.0.0)
    Use -v to see a list of the files searched for.
% hdevtools admin --status
Server is running.
```